### PR TITLE
Add avatar edit page

### DIFF
--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -3,18 +3,50 @@ class AvatarsController < ApplicationController
   TRAITS  = ["Brave", "Clever", "Kind", "Sneaky", "Curious"].freeze
   GENDERS = ["male", "female", "non-binary"].freeze
 
+  before_action :assign_form_options
+
   def new
+    @form_avatar = {}
+    @submitted_avatar = nil
+  end
+
+  def create
+    @form_avatar = avatar_params.to_h.symbolize_keys
+    @submitted_avatar = @form_avatar
+
+    render :new
+  end
+
+  def edit
+    @form_avatar = default_avatar_attributes
+    @submitted_avatar = nil
+  end
+
+  def update
+    @form_avatar = avatar_params.to_h.symbolize_keys
+    @submitted_avatar = @form_avatar
+
+    render :edit
+  end
+
+  private
+
+  def assign_form_options
     @classes = CLASSES
     @traits  = TRAITS
     @genders = GENDERS
   end
 
-  def create
-    @classes = CLASSES
-    @traits  = TRAITS
-    @genders = GENDERS
+  def avatar_params
+    params.require(:avatar).permit(:name, :gender, :klass, traits: [])
+  end
 
-    @input = params.require(:avatar).permit(:name, :gender, :klass, traits: [])
-    render :new
+  def default_avatar_attributes
+    {
+      name: "Astra",
+      gender: "non-binary",
+      klass: "Wizard",
+      traits: %w[Clever Curious]
+    }
   end
 end

--- a/app/views/avatars/_form.html.erb
+++ b/app/views/avatars/_form.html.erb
@@ -1,0 +1,32 @@
+<% avatar = avatar.respond_to?(:to_h) ? avatar.to_h : avatar %>
+<% avatar = (avatar || {}).deep_symbolize_keys %>
+
+<%= form_with url: form_url, scope: :avatar, method: form_method do |f| %>
+  <div>
+    <%= f.label :name, "Name" %><br>
+    <%= f.text_field :name, required: true, value: avatar[:name] %>
+  </div>
+
+  <div style="margin-top: .5rem;">
+    <span>Gender</span><br>
+    <% (@genders || []).each do |g| %>
+      <label style="margin-right: 1rem;">
+        <%= f.radio_button :gender, g, checked: avatar[:gender] == g %> <%= g.humanize %>
+      </label>
+    <% end %>
+  </div>
+
+  <div style="margin-top: .5rem;">
+    <%= f.label :klass, "Class" %><br>
+    <%= f.select :klass, options_for_select(@classes, avatar[:klass]), {}, { required: true } %>
+  </div>
+
+  <div style="margin-top: .5rem;">
+    <%= f.label :traits, "Fun traits" %><br>
+    <%= f.select :traits, options_for_select(@traits, Array(avatar[:traits])), {}, multiple: true, size: 5 %>
+  </div>
+
+  <div style="margin-top: .75rem;">
+    <%= f.submit submit_label, data: { turbo: false } %>
+  </div>
+<% end %>

--- a/app/views/avatars/_submission_summary.html.erb
+++ b/app/views/avatars/_submission_summary.html.erb
@@ -1,0 +1,13 @@
+<% if avatar.present? %>
+  <% avatar = avatar.respond_to?(:to_h) ? avatar.to_h : avatar %>
+  <% avatar = avatar.deep_symbolize_keys %>
+
+  <hr>
+  <h2>Submitted</h2>
+  <ul>
+    <li><strong>Name:</strong> <%= avatar[:name] %></li>
+    <li><strong>Gender:</strong> <%= avatar[:gender] %></li>
+    <li><strong>Class:</strong> <%= avatar[:klass] %></li>
+    <li><strong>Traits:</strong> <%= Array(avatar[:traits]).join(", ") %></li>
+  </ul>
+<% end %>

--- a/app/views/avatars/edit.html.erb
+++ b/app/views/avatars/edit.html.erb
@@ -1,0 +1,11 @@
+<h1>Edit Avatar</h1>
+
+<p>Update your avatar's details and save the changes.</p>
+
+<%= render "form", form_url: avatar_path, form_method: :patch, submit_label: "Save Avatar", avatar: @form_avatar %>
+
+<p style="margin-top: 1rem;">
+  <%= link_to "Back to generator", new_avatar_path %>
+</p>
+
+<%= render "submission_summary", avatar: @submitted_avatar %>

--- a/app/views/avatars/new.html.erb
+++ b/app/views/avatars/new.html.erb
@@ -2,43 +2,8 @@
 
 <p><%= image_tag "avatar-placeholder.svg", alt: "Avatar preview", width: 256, height: 256 %></p>
 
-<%= form_with url: avatars_path, scope: :avatar, method: :post do |f| %>
-  <div>
-    <%= f.label :name, "Name" %><br>
-    <%= f.text_field :name, required: true %>
-  </div>
+<p><%= link_to "Edit an existing avatar", edit_avatar_path %></p>
 
-  <div style="margin-top: .5rem;">
-    <span>Gender</span><br>
-    <% (@genders || []).each do |g| %>
-      <label style="margin-right: 1rem;">
-        <%= f.radio_button :gender, g %> <%= g.humanize %>
-      </label>
-    <% end %>
-  </div>
+<%= render "form", form_url: avatars_path, form_method: :post, submit_label: "Generate", avatar: @form_avatar %>
 
-  <div style="margin-top: .5rem;">
-    <%= f.label :klass, "Class" %><br>
-    <%= f.select :klass, options_for_select(@classes), {}, { required: true } %>
-  </div>
-
-  <div style="margin-top: .5rem;">
-    <%= f.label :traits, "Fun traits" %><br>
-    <%= f.select :traits, options_for_select(@traits), {}, multiple: true, size: 5 %>
-  </div>
-
-  <div style="margin-top: .75rem;">
-    <%= f.submit "Generate", data: { turbo: false } %>
-  </div>
-<% end %>
-
-<% if defined?(@input) && @input.present? %>
-  <hr>
-  <h2>Submitted</h2>
-  <ul>
-    <li><strong>Name:</strong> <%= @input[:name] %></li>
-    <li><strong>Gender:</strong> <%= @input[:gender] %></li>
-    <li><strong>Class:</strong> <%= @input[:klass] %></li>
-    <li><strong>Traits:</strong> <%= Array(@input[:traits]).join(", ") %></li>
-  </ul>
-<% end %>
+<%= render "submission_summary", avatar: @submitted_avatar %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root "avatars#new"
+
+  resource :avatar, only: [:edit, :update]
   resources :avatars, only: [:new, :create]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/avatars_controller_test.rb
+++ b/test/controllers/avatars_controller_test.rb
@@ -2,12 +2,38 @@ require "test_helper"
 
 class AvatarsControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
-    get avatars_new_url
+    get new_avatar_url
     assert_response :success
   end
 
-  test "should get create" do
-    get avatars_create_url
+  test "should create avatar" do
+    post avatars_url, params: {
+      avatar: {
+        name: "Nova",
+        gender: "female",
+        klass: "Wizard",
+        traits: ["Brave"]
+      }
+    }
+
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_avatar_url
+    assert_response :success
+  end
+
+  test "should update avatar" do
+    patch avatar_url, params: {
+      avatar: {
+        name: "Nova",
+        gender: "male",
+        klass: "Knight",
+        traits: ["Kind", "Clever"]
+      }
+    }
+
     assert_response :success
   end
 end


### PR DESCRIPTION
## Summary
- add a dedicated edit/update route for avatars alongside the existing generator
- extract shared form and submission summary partials to support both new and edit pages
- populate the edit experience with default avatar values and link between generator and edit flows

## Testing
- bin/rails test

------
https://chatgpt.com/codex/tasks/task_e_68e2c0d4d8488322bae798e4653f7cb7