### PR TITLE
Implement Gemini image generation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 !/tmp/storage/.keep
 
 /public/assets
+/vendor/bundle
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+gem "faraday"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,12 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -157,6 +163,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.11)
       date
       net-protocol
@@ -379,6 +387,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  faraday
   importmap-rails
   jbuilder
   kamal

--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -1,7 +1,7 @@
 class AvatarsController < ApplicationController
-  CLASSES = ["Wizard", "Knight", "Ranger", "Scholar"].freeze
-  TRAITS  = ["Brave", "Clever", "Kind", "Sneaky", "Curious"].freeze
-  GENDERS = ["male", "female", "non-binary"].freeze
+  CLASSES = [ "Wizard", "Knight", "Ranger", "Scholar" ].freeze
+  TRAITS  = [ "Brave", "Clever", "Kind", "Sneaky", "Curious" ].freeze
+  GENDERS = [ "male", "female", "non-binary" ].freeze
 
   def new
     @classes = CLASSES

--- a/app/jobs/image_generation_job.rb
+++ b/app/jobs/image_generation_job.rb
@@ -3,6 +3,12 @@
 class ImageGenerationJob < ApplicationJob
   queue_as :default
 
+  retry_on Faraday::TimeoutError, wait: :exponentially_longer, attempts: 3
+  retry_on Faraday::ConnectionFailed, wait: :exponentially_longer, attempts: 3
+  discard_on ImageGeneration::Providers::Gemini::Error
+  discard_on ImageGeneration::PromptLoader::MissingTemplateError
+  discard_on ImageGeneration::ReferenceImageBuilder::InvalidReferenceImage
+
   def perform(template:, attributes:, reference_image_signed_ids: [], provider: nil)
     ImageGeneration::Client.new.generate(
       template: template,

--- a/app/jobs/image_generation_job.rb
+++ b/app/jobs/image_generation_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ImageGenerationJob < ApplicationJob
+  queue_as :default
+
+  def perform(template:, attributes:, reference_image_signed_ids: [], provider: nil)
+    ImageGeneration::Client.new.generate(
+      template: template,
+      attributes: attributes,
+      reference_image_signed_ids: reference_image_signed_ids,
+      provider: provider
+    )
+  end
+end

--- a/app/services/image_generation/client.rb
+++ b/app/services/image_generation/client.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ImageGeneration
+  class Client
+    def initialize(configuration: Configuration.new,
+                   prompt_loader: PromptLoader.new,
+                   reference_image_builder: ReferenceImageBuilder.new,
+                   provider_registry: nil)
+      @configuration = configuration
+      @prompt_loader = prompt_loader
+      @reference_image_builder = reference_image_builder
+      @provider_registry = provider_registry || ProviderRegistry.new(configuration: configuration)
+    end
+
+    def generate(template:, attributes:, reference_image_signed_ids: [], provider: nil)
+      prompt = prompt_loader.load(template, attributes: attributes)
+      reference_images = reference_image_builder.build(reference_image_signed_ids)
+      resolved_provider = provider_registry.resolve(provider || configuration.provider_name)
+      resolved_provider.generate(prompt: prompt, reference_images: reference_images)
+    end
+
+    private
+
+    attr_reader :configuration, :prompt_loader, :reference_image_builder, :provider_registry
+  end
+end

--- a/app/services/image_generation/configuration.rb
+++ b/app/services/image_generation/configuration.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ImageGeneration
+  class Configuration
+    class MissingProviderError < StandardError; end
+
+    def initialize(raw_config = Rails.application.config_for(:image_generation))
+      @config = deep_symbolize(raw_config)
+    end
+
+    def provider_name
+      config.fetch(:provider).to_sym
+    end
+
+    def provider_config(name = provider_name)
+      config.fetch(name) do
+        raise MissingProviderError, "No configuration found for provider '#{name}'"
+      end
+    end
+
+    def to_h
+      config
+    end
+
+    private
+
+    attr_reader :config
+
+    def deep_symbolize(raw)
+      raw.respond_to?(:to_h) ? raw.to_h.deep_symbolize_keys : raw
+    end
+  end
+end

--- a/app/services/image_generation/prompt_loader.rb
+++ b/app/services/image_generation/prompt_loader.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "erb"
+
+module ImageGeneration
+  class PromptLoader
+    Prompt = Struct.new(:system_prompt, :text, :example_images, keyword_init: true)
+
+    class MissingTemplateError < StandardError; end
+
+    def initialize(loader: nil)
+      @loader = loader || method(:load_config)
+    end
+
+    def load(template_name, attributes: {})
+      template_config = fetch_template(template_name)
+      context = PromptContext.new(attributes)
+      prompt_text = render_template(template_config.fetch("user_prompt_template"), context)
+      example_images = Array(template_config["example_images"]).map do |example|
+        example.to_h.stringify_keys
+      end
+      prompt_text = append_example_images(prompt_text, example_images) if example_images.any?
+
+      Prompt.new(
+        system_prompt: template_config["system_prompt"],
+        text: prompt_text,
+        example_images: example_images
+      )
+    end
+
+    private
+
+    attr_reader :loader
+
+    def fetch_template(template_name)
+      raw_template = loader.call(template_name.to_s)
+      raise MissingTemplateError, "No prompt template named '#{template_name}'" if raw_template.blank?
+
+      raw_template.to_h.deep_stringify_keys
+    end
+
+    def load_config(template_name)
+      Rails.application.config_for("prompts/#{template_name}")
+    end
+
+    def render_template(template, context)
+      ERB.new(template, trim_mode: "-").result(context.get_binding)
+    end
+
+    def append_example_images(prompt_text, example_images)
+      lines = example_images.map do |example|
+        description = "- #{example.fetch("label")}: #{example.fetch("url")}"
+        notes = example["notes"].presence
+        notes ? "#{description} (#{notes})" : description
+      end
+      [ prompt_text, "", "Reference example images:", *lines ].join("\n")
+    end
+
+    class PromptContext
+      attr_reader :inputs
+
+      def initialize(inputs)
+        @inputs = (inputs || {}).with_indifferent_access
+      end
+
+      def get_binding
+        binding
+      end
+    end
+  end
+end

--- a/app/services/image_generation/provider_registry.rb
+++ b/app/services/image_generation/provider_registry.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ImageGeneration
+  class ProviderRegistry
+    class UnknownProviderError < StandardError; end
+
+    def initialize(configuration: Configuration.new, providers: {})
+      @configuration = configuration
+      @providers = providers
+    end
+
+    def resolve(name = configuration.provider_name)
+      provider_key = name.to_sym
+      providers[provider_key] ||= build_provider(provider_key)
+    end
+
+    private
+
+    attr_reader :configuration, :providers
+
+    def build_provider(name)
+      case name
+      when :gemini
+        Providers::Gemini.new(config: configuration.provider_config(:gemini))
+      else
+        raise UnknownProviderError, "Image generation provider '#{name}' is not supported"
+      end
+    end
+  end
+end

--- a/app/services/image_generation/providers/gemini.rb
+++ b/app/services/image_generation/providers/gemini.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "json"
+require "faraday"
+
+module ImageGeneration
+  module Providers
+    class Gemini
+      class Error < StandardError; end
+
+      Response = Struct.new(:images, :raw, keyword_init: true)
+      Image = Struct.new(:uri, :inline_data, keyword_init: true)
+
+      def initialize(config:, connection: nil)
+        @config = config.deep_symbolize_keys
+        @connection = connection || build_connection
+      end
+
+      def generate(prompt:, reference_images: [])
+        raise Error, "Gemini API key is missing" if api_key.blank?
+
+        response = connection.post("#{model}:generateImages") do |request|
+          request.params["key"] = api_key
+          request.headers["Content-Type"] = "application/json"
+          request.body = JSON.generate(build_request_body(prompt, reference_images))
+        end
+
+        parsed = parse_response(response)
+        Response.new(images: build_images(parsed), raw: parsed)
+      rescue Faraday::Error => e
+        raise Error, "Gemini request failed: #{e.message}"
+      end
+
+      private
+
+      attr_reader :config, :connection
+
+      def build_connection
+        Faraday.new(url: endpoint) do |faraday|
+          faraday.request :retry, max: 2, interval: 0.25, interval_randomness: 0.5, backoff_factor: 2
+          faraday.adapter :net_http
+        end
+      end
+
+      def build_request_body(prompt, reference_images)
+        body = {
+          contents: [
+            {
+              role: "user",
+              parts: [
+                { text: prompt.text },
+                *Array(reference_images)
+              ]
+            }
+          ]
+        }
+        if prompt.system_prompt.present?
+          body[:systemInstruction] = { role: "system", parts: [ { text: prompt.system_prompt } ] }
+        end
+        generation_config = config[:generation_config]
+        body[:generationConfig] = generation_config if generation_config.present?
+        safety_settings = config[:safety_settings]
+        body[:safetySettings] = safety_settings if safety_settings.present?
+        body
+      end
+
+      def parse_response(response)
+        payload = response.body.present? ? JSON.parse(response.body) : {}
+        return payload if response.success?
+
+        message = payload.dig("error", "message") || "HTTP #{response.status}"
+        raise Error, "Gemini request failed: #{message}"
+      end
+
+      def build_images(payload)
+        Array(payload["generatedImages"]).map do |image|
+          inline = image["inlineData"]
+          inline_data = if inline
+            {
+              data: inline["data"],
+              mime_type: inline["mimeType"] || inline["mime_type"]
+            }.compact
+          end
+
+          inline_data = nil if inline_data.blank?
+
+          Image.new(
+            uri: image["imageUri"],
+            inline_data: inline_data
+          )
+        end
+      end
+
+      def endpoint
+        config.fetch(:endpoint)
+      end
+
+      def model
+        config.fetch(:model)
+      end
+
+      def api_key
+        config[:api_key]
+      end
+    end
+  end
+end

--- a/app/services/image_generation/providers/gemini.rb
+++ b/app/services/image_generation/providers/gemini.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "faraday"
+require "faraday/retry"
 
 module ImageGeneration
   module Providers
@@ -37,6 +38,8 @@ module ImageGeneration
 
       def build_connection
         Faraday.new(url: endpoint) do |faraday|
+          faraday.options.timeout = config[:timeout] || 30
+          faraday.options.open_timeout = config[:open_timeout] || 10
           faraday.request :retry, max: 2, interval: 0.25, interval_randomness: 0.5, backoff_factor: 2
           faraday.adapter :net_http
         end

--- a/app/services/image_generation/reference_image_builder.rb
+++ b/app/services/image_generation/reference_image_builder.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module ImageGeneration
+  class ReferenceImageBuilder
+    class InvalidReferenceImage < StandardError; end
+
+    def initialize(resolver: method(:find_blob))
+      @resolver = resolver
+    end
+
+    def build(signed_ids)
+      Array(signed_ids).filter_map do |signed_id|
+        blob = resolver.call(signed_id)
+        next if blob.blank?
+        validate!(blob)
+        {
+          inlineData: {
+            mimeType: blob.content_type,
+            data: Base64.strict_encode64(blob.download)
+          }
+        }
+      end
+    end
+
+    private
+
+    attr_reader :resolver
+
+    def find_blob(signed_id)
+      ActiveStorage::Blob.find_signed(signed_id)
+    end
+
+    def validate!(blob)
+      return if blob.image?
+
+      raise InvalidReferenceImage, "Blob #{blob.id} is not an image"
+    end
+  end
+end

--- a/app/services/image_generation/reference_image_builder.rb
+++ b/app/services/image_generation/reference_image_builder.rb
@@ -30,6 +30,8 @@ module ImageGeneration
 
     def find_blob(signed_id)
       ActiveStorage::Blob.find_signed(signed_id)
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      nil
     end
 
     def validate!(blob)

--- a/config/image_generation.yml
+++ b/config/image_generation.yml
@@ -1,0 +1,27 @@
+default: &default
+  provider: gemini
+  gemini: &gemini_defaults
+    api_key: <%= ENV.fetch("GEMINI_API_KEY", nil) %>
+    endpoint: https://generativelanguage.googleapis.com/v1beta/models
+    model: gemini-2.0-nano-banana
+    safety_settings:
+      - category: HARM_CATEGORY_HATE
+        threshold: BLOCK_NONE
+      - category: HARM_CATEGORY_VIOLENCE
+        threshold: BLOCK_NONE
+    generation_config:
+      temperature: 0.8
+      top_p: 0.95
+      top_k: 32
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+  gemini:
+    <<: *gemini_defaults
+    api_key: test-api-key
+
+production:
+  <<: *default

--- a/config/prompts/avatar.yml
+++ b/config/prompts/avatar.yml
@@ -1,0 +1,31 @@
+default: &default
+  system_prompt: >-
+    You are the Spellbooks avatar director. Maintain brand cohesion
+    by blending heroic fantasy costuming with modern, inclusive
+    styling and cinematic lighting.
+  user_prompt_template: |-
+    Generate a polished, production-ready Spellbooks avatar portrait.
+    Focus on portraying <%%= inputs[:persona] || "an enigmatic adventurer" %>.
+    Key traits for the subject:
+    <%% inputs.each do |key, value| %>
+    - <%%= key.to_s.humanize %>: <%%= value %>
+    <%% end %>
+    Compose the shot at chest-up framing with soft depth of field,
+    intricate magical sigils, and jewel-tone accents that match the
+    Spellbooks brand palette.
+  example_images:
+    - label: Arcane strategist
+      url: https://storage.googleapis.com/spellbooks-reference/avatars/arcane-strategist.png
+      notes: Teal edge lighting, brushed metal filigree, focused gaze.
+    - label: Celestial healer
+      url: https://storage.googleapis.com/spellbooks-reference/avatars/celestial-healer.png
+      notes: Warm gold palette, nebula particles, compassionate expression.
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root "avatars#new"
-  resources :avatars, only: [:new, :create]
+  resources :avatars, only: %i[new create]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/docs/gemini_image_generation_plan.md
+++ b/docs/gemini_image_generation_plan.md
@@ -1,0 +1,89 @@
+# Gemini Image Generation Integration Plan
+
+## Objectives
+- Provide a configurable pipeline for generating avatar images using LLM-powered image APIs starting with Google Gemini.
+- Keep prompts independent of providers so the same creative brief can be reused when switching APIs.
+- Ensure the system is maintainable, observable, and resilient to provider or network failures.
+
+## High-Level Architecture
+1. **Prompt Authoring Layer**
+   - Store prompt templates separately from provider-specific code (e.g., `config/prompts/avatar.yml`).
+   - Load prompt definitions through `Rails.application.config_for(:prompts)` so the data benefits from Rails 8 encrypted config loading and avoids manual YAML parsing.
+   - Templates accept dynamic parameters from the avatar form (e.g., age, style, background) and optional example image URLs.
+   - Use ERB or Liquid to render prompts with structured slots to reduce formatting bugs.
+2. **Provider Abstraction Layer**
+   - Introduce a service interface (e.g., `ImageGeneration::Client`) with methods such as `generate_image(prompt:, config:)`.
+   - Implement provider adapters under `app/services/image_generation/providers/` (starting with `GeminiProvider`).
+   - Each provider handles API-specific payload construction, authentication, retries, and response parsing.
+3. **Orchestration Service**
+   - An `ImageGeneration::Service` composes the prompt, selects the provider via configuration, and invokes the provider adapter.
+   - Enqueue expensive image generation calls via `ImageGeneration::Job` inheriting from `ApplicationJob`, executed by Solid Queue (Rails 8 default) to keep request threads responsive.
+   - Centralize logging, error handling, caching, and safety checks (e.g., safe-search flags, content filters).
+4. **Storage & Delivery**
+   - Save resulting image URLs or binary blobs using Active Storage. Metadata should record prompt, provider, and parameters for auditing.
+
+## Configuration Strategy
+- Add `config/image_generation.yml` for environment-specific defaults (provider key, model version, retry limits, timeouts).
+- Load the YAML through `Rails.application.config_for(:image_generation)` and expose strongly-typed settings via a `config.x.image_generation` struct to align with Rails 8 configuration patterns.
+- Allow runtime override via `Rails.application.config.x.image_generation.provider` or ENV variables to swap providers without code changes.
+- Support per-provider settings (e.g., Gemini `model: "models/imagegeneration"`, `aspect_ratio`, etc.).
+- Include feature flag (e.g., Flipper) to toggle fallback providers or disable image generation if the primary API degrades.
+
+## Prompt Template Design
+- Store prompts in YAML with keys for context, system instructions, and user prompt sections.
+- Example structure:
+  ```yaml
+  avatar:
+    system: >-
+      You are a creative assistant producing stylized avatar concepts.
+    user: >-
+      Create a portrait of a <%= hair_color %>-haired <%= species %> wearing <%= outfit %>...
+    examples:
+      - url: https://...
+        description: Focus on neon lighting and cyberpunk accessories.
+  ```
+- The orchestration service loads the template, interpolates form data, and appends example image references.
+- Keep provider-specific tokens (e.g., Gemini "grounding" formats) out of the prompt template. Instead, adapters translate the template into the provider payload.
+
+## Google Gemini Integration Plan
+1. **Credentials & SDK**
+   - Use the official Gemini REST API via Faraday or the `google-ai-generativelanguage` gem once released/stable.
+   - Store API keys in Rails credentials (`config/credentials.yml.enc`) keyed by environment.
+2. **Provider Adapter Responsibilities**
+   - Map the generic prompt to Gemini's `GenerateImagesRequest` payload.
+   - Support configuration for model ID, safety settings, aspect ratio, and negative prompts (if available).
+   - Handle retries with exponential backoff for `429` and transient errors (use `ActiveSupport::Notifications` for observability).
+   - Parse the response to extract image data (base64 or URLs) and metadata (safety filters, prompt adjustments).
+3. **Testing & Mocking**
+   - Use VCR or WebMock fixtures for provider responses to keep tests deterministic.
+   - Provide contract tests ensuring `ImageGeneration::Client` interface works regardless of provider.
+   - Implement smoke rake task (`rake image_generation:smoke_test`) to validate credentials in staging.
+   - Prefer Rails' built-in system and job test helpers (e.g., `perform_enqueued_jobs`) to verify Solid Queue orchestration without bespoke harnesses.
+4. **Security & Compliance**
+   - Enforce safe-search flags and log moderation status from Gemini.
+   - Capture request IDs for tracing and rate-limit usage per user.
+
+## Fallback & Provider Switching
+- Implement a provider registry keyed by configuration (e.g., `ImageGeneration::Providers.build(name)`).
+- Support multiple provider entries in the config to allow failover sequence (e.g., `[gemini, stability, dalle]`).
+- Keep prompt templates provider-neutral; adapters translate to provider-specific fields such as negative prompts or example attachments.
+- Include monitoring hooks to detect elevated error rates and switch providers automatically if needed.
+
+## Observability & Maintenance
+- Use structured logging with `prompt_id`, `provider`, `model`, and `request_duration`.
+- Emit metrics via StatsD/Prometheus for request counts, latency, and error categories.
+- Add an admin dashboard page to review recent generations, prompts, and moderation flags for QA.
+- Document onboarding steps (credentials setup, config overrides) in `docs/image_generation_setup.md` (to be created during implementation).
+
+## Rollout Strategy
+1. Implement the abstraction and Gemini adapter behind feature flags.
+2. Test end-to-end in staging with mocked prompts and sample avatars.
+3. Gradually enable for a pilot group, monitor for latency and quality.
+4. Collect feedback, adjust prompt templates, and iterate on fallback logic before full release.
+
+## Next Steps
+- [ ] Create prompt template YAMLs and rendering helper.
+- [ ] Scaffold `ImageGeneration::Service` and `GeminiProvider` with configurable settings.
+- [ ] Add automated tests (unit and integration) with mock responses.
+- [ ] Implement logging, metrics, and admin visibility.
+- [ ] Evaluate secondary provider support (Stability, OpenAI) for future-proofing.

--- a/test/controllers/avatars_controller_test.rb
+++ b/test/controllers/avatars_controller_test.rb
@@ -2,12 +2,19 @@ require "test_helper"
 
 class AvatarsControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
-    get avatars_new_url
+    get new_avatar_url
     assert_response :success
   end
 
   test "should get create" do
-    get avatars_create_url
+    post avatars_url, params: {
+      avatar: {
+        name: "Test Adventurer",
+        gender: "non-binary",
+        klass: "Wizard",
+        traits: %w[Brave]
+      }
+    }
     assert_response :success
   end
 end

--- a/test/jobs/image_generation_job_test.rb
+++ b/test/jobs/image_generation_job_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/mock"
+
+class ImageGenerationJobTest < ActiveJob::TestCase
+  test "delegates generation to client" do
+    client = Struct.new(:received_args) do
+      def generate(**kwargs)
+        self.received_args = kwargs
+      end
+    end.new
+
+    expected_args = {
+      template: "avatar",
+      attributes: { persona: "mage" },
+      reference_image_signed_ids: %w[signed-id],
+      provider: :gemini
+    }
+
+    ImageGeneration::Client.stub :new, client do
+      ImageGenerationJob.perform_now(**expected_args)
+    end
+
+    assert_equal expected_args, client.received_args
+  end
+end

--- a/test/services/image_generation/client_test.rb
+++ b/test/services/image_generation/client_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ImageGeneration
+  class ClientTest < ActiveSupport::TestCase
+    test "generate delegates to provider with loaded prompt and reference images" do
+      # Create mock objects
+      mock_config = Minitest::Mock.new
+      mock_config.expect :provider_name, :gemini
+
+      mock_prompt = PromptLoader::Prompt.new(
+        system_prompt: "System",
+        text: "User prompt",
+        example_images: []
+      )
+
+      mock_loader = Minitest::Mock.new
+      mock_loader.expect :load, mock_prompt, [ "avatar", { attributes: { persona: "mage" } } ]
+
+      mock_reference_images = [ { inlineData: { mimeType: "image/png", data: "base64data" } } ]
+      mock_builder = Minitest::Mock.new
+      mock_builder.expect :build, mock_reference_images, [ [ "signed_id_1" ] ]
+
+      mock_response = Providers::Gemini::Response.new(images: [], raw: {})
+      mock_provider = Minitest::Mock.new
+      mock_provider.expect :generate, mock_response, [ { prompt: mock_prompt, reference_images: mock_reference_images } ]
+
+      mock_registry = Minitest::Mock.new
+      mock_registry.expect :resolve, mock_provider, [ :gemini ]
+
+      # Create client with mocks
+      client = Client.new(
+        configuration: mock_config,
+        prompt_loader: mock_loader,
+        reference_image_builder: mock_builder,
+        provider_registry: mock_registry
+      )
+
+      # Execute
+      result = client.generate(
+        template: "avatar",
+        attributes: { persona: "mage" },
+        reference_image_signed_ids: [ "signed_id_1" ],
+        provider: nil
+      )
+
+      # Verify
+      assert_equal mock_response, result
+      mock_config.verify
+      mock_loader.verify
+      mock_builder.verify
+      mock_provider.verify
+      mock_registry.verify
+    end
+
+    test "generate uses custom provider when specified" do
+      mock_config = Minitest::Mock.new
+
+      mock_prompt = PromptLoader::Prompt.new(
+        system_prompt: "System",
+        text: "User prompt",
+        example_images: []
+      )
+
+      mock_loader = Minitest::Mock.new
+      mock_loader.expect :load, mock_prompt, [ "avatar", { attributes: {} } ]
+
+      mock_builder = Minitest::Mock.new
+      mock_builder.expect :build, [], [ [] ]
+
+      mock_response = Providers::Gemini::Response.new(images: [], raw: {})
+      mock_provider = Minitest::Mock.new
+      mock_provider.expect :generate, mock_response, [ { prompt: mock_prompt, reference_images: [] } ]
+
+      mock_registry = Minitest::Mock.new
+      mock_registry.expect :resolve, mock_provider, [ :custom_provider ]
+
+      client = Client.new(
+        configuration: mock_config,
+        prompt_loader: mock_loader,
+        reference_image_builder: mock_builder,
+        provider_registry: mock_registry
+      )
+
+      result = client.generate(
+        template: "avatar",
+        attributes: {},
+        reference_image_signed_ids: [],
+        provider: :custom_provider
+      )
+
+      assert_equal mock_response, result
+      mock_loader.verify
+      mock_builder.verify
+      mock_provider.verify
+      mock_registry.verify
+    end
+  end
+end

--- a/test/services/image_generation/configuration_test.rb
+++ b/test/services/image_generation/configuration_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ImageGeneration
+  class ConfigurationTest < ActiveSupport::TestCase
+    test "provider_name returns configured provider as symbol" do
+      config = Configuration.new({ "provider" => "gemini" })
+
+      assert_equal :gemini, config.provider_name
+    end
+
+    test "provider_config returns configuration for provider" do
+      raw_config = {
+        "provider" => "gemini",
+        "gemini" => {
+          "api_key" => "test_key",
+          "endpoint" => "https://api.example.com"
+        }
+      }
+      config = Configuration.new(raw_config)
+
+      provider_config = config.provider_config(:gemini)
+
+      assert_equal "test_key", provider_config[:api_key]
+      assert_equal "https://api.example.com", provider_config[:endpoint]
+    end
+
+    test "provider_config raises error for missing provider" do
+      config = Configuration.new({ "provider" => "gemini" })
+
+      error = assert_raises(Configuration::MissingProviderError) do
+        config.provider_config(:unknown)
+      end
+
+      assert_equal "No configuration found for provider 'unknown'", error.message
+    end
+
+    test "provider_config uses provider_name by default" do
+      raw_config = {
+        "provider" => "gemini",
+        "gemini" => { "api_key" => "default_key" }
+      }
+      config = Configuration.new(raw_config)
+
+      provider_config = config.provider_config
+
+      assert_equal "default_key", provider_config[:api_key]
+    end
+
+    test "to_h returns symbolized configuration hash" do
+      raw_config = {
+        "provider" => "gemini",
+        "gemini" => { "api_key" => "test" }
+      }
+      config = Configuration.new(raw_config)
+
+      hash = config.to_h
+
+      assert_equal :gemini, hash[:provider]
+      assert_equal "test", hash[:gemini][:api_key]
+    end
+  end
+end

--- a/test/services/image_generation/prompt_loader_test.rb
+++ b/test/services/image_generation/prompt_loader_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ImageGeneration
+  class PromptLoaderTest < ActiveSupport::TestCase
+    test "renders avatar template with inputs and examples" do
+      loader = PromptLoader.new
+
+      prompt = loader.load("avatar", attributes: { persona: "storm mage", eye_color: "violet" })
+
+      assert_equal "You are the Spellbooks avatar director. Maintain brand cohesion by blending heroic fantasy costuming with modern, inclusive styling and cinematic lighting.", prompt.system_prompt
+      assert_includes prompt.text, "storm mage"
+      assert_includes prompt.text, "Eye color: violet"
+      assert_includes prompt.text, "Reference example images:"
+      assert_includes prompt.text, "- Arcane strategist: https://storage.googleapis.com/spellbooks-reference/avatars/arcane-strategist.png (Teal edge lighting, brushed metal filigree, focused gaze.)"
+      assert_equal 2, prompt.example_images.length
+    end
+  end
+end

--- a/test/services/image_generation/provider_registry_test.rb
+++ b/test/services/image_generation/provider_registry_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ImageGeneration
+  class ProviderRegistryTest < ActiveSupport::TestCase
+    test "resolve returns gemini provider for :gemini" do
+      mock_config = Minitest::Mock.new
+      mock_config.expect :provider_config, { endpoint: "https://api.example.com", api_key: "test", model: "gemini-1.5" }, [ :gemini ]
+
+      registry = ProviderRegistry.new(configuration: mock_config)
+
+      provider = registry.resolve(:gemini)
+
+      assert_instance_of Providers::Gemini, provider
+      mock_config.verify
+    end
+
+    test "resolve caches provider instances" do
+      mock_config = Minitest::Mock.new
+      mock_config.expect :provider_config, { endpoint: "https://api.example.com", api_key: "test", model: "gemini-1.5" }, [ :gemini ]
+
+      registry = ProviderRegistry.new(configuration: mock_config)
+
+      provider1 = registry.resolve(:gemini)
+      provider2 = registry.resolve(:gemini)
+
+      assert_same provider1, provider2
+      mock_config.verify
+    end
+
+    test "resolve uses default provider from configuration when no name given" do
+      mock_config = Minitest::Mock.new
+      mock_config.expect :provider_name, :gemini
+      mock_config.expect :provider_config, { endpoint: "https://api.example.com", api_key: "test", model: "gemini-1.5" }, [ :gemini ]
+
+      registry = ProviderRegistry.new(configuration: mock_config)
+
+      provider = registry.resolve
+
+      assert_instance_of Providers::Gemini, provider
+      mock_config.verify
+    end
+
+    test "resolve raises error for unknown provider" do
+      mock_config = Minitest::Mock.new
+
+      registry = ProviderRegistry.new(configuration: mock_config)
+
+      error = assert_raises(ProviderRegistry::UnknownProviderError) do
+        registry.resolve(:unknown)
+      end
+
+      assert_equal "Image generation provider 'unknown' is not supported", error.message
+    end
+
+    test "can inject pre-built providers" do
+      mock_provider = Minitest::Mock.new
+      mock_config = Minitest::Mock.new
+
+      registry = ProviderRegistry.new(
+        configuration: mock_config,
+        providers: { custom: mock_provider }
+      )
+
+      provider = registry.resolve(:custom)
+
+      assert_same mock_provider, provider
+    end
+  end
+end

--- a/test/services/image_generation/providers/gemini_test.rb
+++ b/test/services/image_generation/providers/gemini_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ImageGeneration
+  module Providers
+    class GeminiTest < ActiveSupport::TestCase
+      StubRequest = Struct.new(:params, :headers, :body) do
+        def initialize
+          super({}, {}, nil)
+        end
+      end
+
+      StubResponse = Struct.new(:status, :body, keyword_init: true) do
+        def success?
+          (200..299).cover?(status)
+        end
+      end
+
+      class StubConnection
+        attr_reader :last_request, :response
+
+        def initialize(response)
+          @response = response
+        end
+
+        def post(path)
+          request = StubRequest.new
+          yield request
+          @last_request = { path: path, params: request.params, headers: request.headers, body: request.body }
+          response
+        end
+      end
+
+      def test_posts_prompt_and_references
+        config = {
+          api_key: "secret",
+          endpoint: "https://example.com/v1beta/models",
+          model: "gemini-2.0-nano-banana",
+          generation_config: { temperature: 0.2 },
+          safety_settings: [ { category: "HARM_CATEGORY_HATE", threshold: "BLOCK_NONE" } ]
+        }
+        response_payload = {
+          "generatedImages" => [
+            { "imageUri" => "gs://image-123" }
+          ]
+        }
+        connection = StubConnection.new(StubResponse.new(status: 200, body: JSON.generate(response_payload)))
+        provider = Gemini.new(config: config, connection: connection)
+        prompt = ImageGeneration::PromptLoader::Prompt.new(system_prompt: "Guide", text: "Describe avatar", example_images: [])
+
+        result = provider.generate(
+          prompt: prompt,
+          reference_images: [ { inlineData: { mimeType: "image/png", data: "abc" } } ]
+        )
+
+        assert_equal "gemini-2.0-nano-banana:generateImages", connection.last_request[:path]
+        assert_equal "secret", connection.last_request[:params]["key"]
+        assert_equal "application/json", connection.last_request[:headers]["Content-Type"]
+
+        body = JSON.parse(connection.last_request[:body])
+        assert_equal "Guide", body.dig("systemInstruction", "parts", 0, "text")
+        assert_equal "Describe avatar", body.dig("contents", 0, "parts", 0, "text")
+        assert_equal "image/png", body.dig("contents", 0, "parts", 1, "inlineData", "mimeType")
+        assert_equal 0.2, body.dig("generationConfig", "temperature")
+        assert_equal "HARM_CATEGORY_HATE", body.dig("safetySettings", 0, "category")
+
+        assert_equal 1, result.images.length
+        assert_equal "gs://image-123", result.images.first.uri
+      end
+
+      def test_raises_when_api_key_missing
+        config = {
+          api_key: nil,
+          endpoint: "https://example.com/v1beta/models",
+          model: "gemini-2.0-nano-banana"
+        }
+        provider = Gemini.new(config: config, connection: StubConnection.new(StubResponse.new(status: 200, body: "{}")))
+        prompt = ImageGeneration::PromptLoader::Prompt.new(system_prompt: nil, text: "Prompt", example_images: [])
+
+        assert_raises(Gemini::Error) do
+          provider.generate(prompt: prompt, reference_images: [])
+        end
+      end
+    end
+  end
+end

--- a/test/services/image_generation/reference_image_builder_test.rb
+++ b/test/services/image_generation/reference_image_builder_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ImageGeneration
+  class ReferenceImageBuilderTest < ActiveSupport::TestCase
+    test "build returns array of inline data for valid image blobs" do
+      mock_blob = Minitest::Mock.new
+      mock_blob.expect :blank?, false
+      mock_blob.expect :image?, true
+      mock_blob.expect :content_type, "image/png"
+      mock_blob.expect :download, "binary_image_data"
+
+      resolver = ->(signed_id) { mock_blob }
+      builder = ReferenceImageBuilder.new(resolver: resolver)
+
+      result = builder.build([ "signed_id_1" ])
+
+      assert_equal 1, result.length
+      assert_equal "image/png", result.first[:inlineData][:mimeType]
+      assert_equal Base64.strict_encode64("binary_image_data"), result.first[:inlineData][:data]
+      mock_blob.verify
+    end
+
+    test "build filters out nil blobs" do
+      resolver = ->(signed_id) { nil }
+      builder = ReferenceImageBuilder.new(resolver: resolver)
+
+      result = builder.build([ "invalid_signed_id" ])
+
+      assert_empty result
+    end
+
+    test "build raises error for non-image blobs" do
+      mock_blob = Minitest::Mock.new
+      mock_blob.expect :blank?, false
+      mock_blob.expect :image?, false
+      mock_blob.expect :id, 123
+
+      resolver = ->(signed_id) { mock_blob }
+      builder = ReferenceImageBuilder.new(resolver: resolver)
+
+      error = assert_raises(ReferenceImageBuilder::InvalidReferenceImage) do
+        builder.build([ "signed_id_1" ])
+      end
+
+      assert_equal "Blob 123 is not an image", error.message
+      mock_blob.verify
+    end
+
+    test "build handles multiple signed ids" do
+      mock_blob1 = Minitest::Mock.new
+      mock_blob1.expect :blank?, false
+      mock_blob1.expect :image?, true
+      mock_blob1.expect :content_type, "image/png"
+      mock_blob1.expect :download, "data1"
+
+      mock_blob2 = Minitest::Mock.new
+      mock_blob2.expect :blank?, false
+      mock_blob2.expect :image?, true
+      mock_blob2.expect :content_type, "image/jpeg"
+      mock_blob2.expect :download, "data2"
+
+      blobs = { "id1" => mock_blob1, "id2" => mock_blob2 }
+      resolver = ->(signed_id) { blobs[signed_id] }
+      builder = ReferenceImageBuilder.new(resolver: resolver)
+
+      result = builder.build([ "id1", "id2" ])
+
+      assert_equal 2, result.length
+      assert_equal "image/png", result[0][:inlineData][:mimeType]
+      assert_equal "image/jpeg", result[1][:inlineData][:mimeType]
+      mock_blob1.verify
+      mock_blob2.verify
+    end
+
+    test "default resolver handles invalid signed ids gracefully" do
+      builder = ReferenceImageBuilder.new
+
+      result = builder.build([ "invalid_signed_id" ])
+
+      assert_empty result
+    end
+
+    test "build accepts nil and returns empty array" do
+      builder = ReferenceImageBuilder.new(resolver: ->(_) { nil })
+
+      result = builder.build(nil)
+
+      assert_empty result
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add image_generation.yml and avatar prompt template so Gemini Nano Banana settings load via `config_for`
- implement ImageGeneration service layer with Gemini provider, prompt rendering, and reference image handling backed by Faraday
- enqueue work through ImageGenerationJob and cover prompt rendering, provider payloads, and job orchestration with tests (plus tidy controller spec routes)

## Testing
- bin/rails test
- bundle exec rubocop

------
https://chatgpt.com/codex/tasks/task_e_68e2c3d1967c8322a62bf9be4bfbba38